### PR TITLE
fix(doc-processor): handle errors thrown in processors better

### DIFF
--- a/lib/doc-processor.js
+++ b/lib/doc-processor.js
@@ -115,8 +115,19 @@ module.exports = function docProcessorFactory(config) {
 
           // The processor should return a promise, a new docs object or undefined
           return docsInjector.invoke(processor.process) || docs;
+        }).catch(function(error) {
+          error.message = 'Error running processor "' + processor.name + '":\n' + error.message;
+          if ( config.processing.stopOnError ) {
+            throw error;
+          } else {
+            log.error(error.stack);
+          }
         });
       }
+    });
+
+    processingPromise.catch(function(error) {
+      log.error('Error processing docs:\n' + error.stack);
     });
 
     return processingPromise;


### PR DESCRIPTION
The doc processor should now provide better logging of errors that occur inside individual doc-processors.
In addition, if the new `config.processing.stopOnError` is set to true (default: false) then the processing will stop at the processor that failed.
