### PR TITLE
fix(README): update the myDocProcessor.js example to clarify that $process is a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ You define Processors just like you would a Service:
 ```js
 module.exports = function myDocProcessor(dependency1, dependency2) {
   return {
-    $process(docs) { ... do stuff with the docs ... }
+    $process: function (docs) { ... do stuff with the docs ... }
     $runAfter: ['otherProcessor1'],
     $runBefore: ['otherProcessor2', 'otherProcessor3'],
     $validate: {


### PR DESCRIPTION
Added the `function` keyword.
