### PR TITLE
fix(README_fr_FR): update the myDocProcessor.js example to clarify that ...

### DIFF
--- a/README_fr_FR.md
+++ b/README_fr_FR.md
@@ -172,7 +172,7 @@ Vous définissez les Processeurs comme vous le feriez pour un Service :
 ```js
 module.exports = function myDocProcessor(dependency1, dependency2) {
   return {
-    $process(docs) { ... faire des choses avec les docs ... }
+    $process: function (docs) { ... faire des choses avec les docs ... }
     $runAfter: ['otherProcessor1'],
     $runBefore: ['otherProcessor2', 'otherProcessor3'],
     $validate: {


### PR DESCRIPTION
...$process is a function.

Added the `function` keyword.
