### PR TITLE
Bump winston dependency to avoid brining in deps that require node 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "canonical-path": "~0.0.2",
     "dependency-graph": "~0.1.0",
     "di": "0.0.1",
-    "optimist": "~0.6.0",
     "lodash": "^2.4.1",
+    "optimist": "~0.6.0",
     "q": "~0.9.7",
     "validate.js": "^0.2.0",
-    "winston": "~0.7.2"
+    "winston": "^1.1.2"
   },
   "devDependencies": {
     "dgeni-packages": "^0.10.0",


### PR DESCRIPTION
Fixes #126, also bump minor version number as this constitutes a breaking change as winston is exposed.