### PR TITLE
chore: update according to #itsjustangular

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
-* [Angular.js Contributing Doc](https://github.com/angular/angular.js/blob/CONTRIBUTING.md)
+* [AngularJS Contributing Doc](https://github.com/angular/angular.js/blob/CONTRIBUTING.md)
 
 [roadmap]: http://github.com/angular/dgeni/blob/master/ROADMAP.md
 [issues]: https://github.com/angular/dgeni/issues?state=open

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Watch Pete's ng-europe talk on Dgeni :
 [![ScreenShot](http://img.youtube.com/vi/PQNROxXajyQ/0.jpg)](http://youtu.be/PQNROxXajyQ)
 
 
-## Documenting Angular 1 Apps
+## Documenting AngularJS Apps
 
-There are two projects out there that build upon dgeni to help create documentation for Angular 1 apps:
+There are two projects out there that build upon dgeni to help create documentation for AngularJS apps:
 
 * dgeni-alive: https://github.com/wingedfox/dgeni-alive
 * sia: https://github.com/boundstate/sia

--- a/README_fr_FR.md
+++ b/README_fr_FR.md
@@ -16,9 +16,9 @@ Regardez la présentation de Pete sur Dgeni (En anglais) :
 [![ScreenShot](http://img.youtube.com/vi/PQNROxXajyQ/0.jpg)](http://youtu.be/PQNROxXajyQ)
 
 
-## Documenter les applications Angular 1
+## Documenter les applications AngularJS
 
-Il existe deux projets qui s'appuient sur dgeni pour vous aider à créer la documentation pour les applications Angular 1 :
+Il existe deux projets qui s'appuient sur dgeni pour vous aider à créer la documentation pour les applications AngularJS :
 
 * dgeni-alive: https://github.com/wingedfox/dgeni-alive
 * sia: https://github.com/boundstate/sia

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ dgeni its document processing super-powers.
 ### Releases
 * v0.9.4 - bug fixes
 * v0.10.0 - no-config (to match the dgeni 0.4.0 release)
-* v0.11.0 - packages to support easy documenting of angular apps
+* v0.11.0 - packages to support easy documenting of AngularJS apps
 * v0.12.0
     - better jsdoc processing
     - coffeescript & es6 file support
@@ -59,11 +59,11 @@ searching and display of the hosted docs.
 * It should be able to host multiple versions of a project
 * It should allow linking between components in different projects/versions
 
-## angular.js docs
+## AngularJS docs
 
-The angular.js docs website and the original consumer of dgeni.  We need to keep this updated with
-the latest changes to dgeni.  Moving forward AngularJS V2 consists of multiple interdependent projects,
-written in ES6, which will all need a website (see dgeni-docs) to display their documentation.
+The AngularJS docs website and the original consumer of dgeni.  We need to keep this updated with
+the latest changes to dgeni.  Moving forward Angular consists of multiple interdependent projects,
+written in TypeScript, which will all need a website (see dgeni-docs) to display their documentation.
 
 
 [contributing]: https://github.com/angular/dgeni/blob/master/CONTRIBUTING.md

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dgeni",
   "version": "0.4.7",
-  "description": "Flexible JavaScript documentation generator used by Angular",
+  "description": "Flexible JavaScript documentation generator used by both AngularJS and Angular",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "bin": {


### PR DESCRIPTION
previously, several documents contained `Angular 1` or `Angular`, while it's supposed to be `AngularJS`.

This commit ensures the readme is up to date according to @IgorMinar 's tweets and the presskit (#itsjustangular) 😀  .

