### PR TITLE
chore(package): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild": "rm -rf lib",
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "mocha --compilers ts:ts-node/register -R spec src/**/*.spec.ts",
+    "test": "mocha --require ts-node/register -R spec src/**/*.spec.ts",
     "docs": "node lib/gen-docs.js ./docs/dgeni-docs.js"
   },
   "repository": {
@@ -27,26 +27,26 @@
   "license": "MIT",
   "dependencies": {
     "canonical-path": "~0.0.2",
-    "dependency-graph": "~0.4.1",
+    "dependency-graph": "^0.7.0",
     "di": "0.0.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.10",
     "objectdiff": "^1.1.0",
     "optimist": "~0.6.1",
-    "q": "~1.4.1",
-    "validate.js": "^0.9.0",
+    "q": "^1.5.1",
+    "validate.js": "^0.12.0",
     "winston": "^2.1.1"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.34",
-    "@types/mocha": "^2.2.39",
-    "@types/node": "^7.0.5",
-    "chai": "^3.5.0",
-    "chai-spies": "^0.7.1",
-    "dgeni-packages": "^0.16.0",
-    "mocha": "^3.2.0",
-    "ts-node": "^2.1.0",
-    "tslint": "^4.4.2",
-    "typescript": "^2.1.6"
+    "@types/chai": "^4.1.3",
+    "@types/mocha": "^5.2.1",
+    "@types/node": "^10.3.1",
+    "chai": "^4.1.2",
+    "chai-spies": "^1.0.0",
+    "dgeni-packages": "^0.26.0",
+    "mocha": "^5.2.0",
+    "ts-node": "^6.1.0",
+    "tslint": "^5.10.0",
+    "typescript": "^2.9.1"
   },
   "contributors": [
     "Pete Bacon Darwin <pete@bacondarwin.com>",

--- a/src/legacyPackages/processorValidation.spec.ts
+++ b/src/legacyPackages/processorValidation.spec.ts
@@ -8,7 +8,7 @@ describe('processorValidation', () => {
   let dgeni, mockLogger;
 
   beforeEach(() => {
-    mockLogger = spy.object('log', ['error', 'warning', 'info', 'debug', 'silly']);
+    mockLogger = spy.interface('log', ['error', 'warning', 'info', 'debug', 'silly']);
     dgeni = new Dgeni();
     const mockLoggerPackage = dgeni.package('mockLogger');
     mockLoggerPackage.factory(function log() { return mockLogger; });

--- a/src/packages/docDiffLogger.spec.ts
+++ b/src/packages/docDiffLogger.spec.ts
@@ -8,7 +8,7 @@ describe('docDiffLogger', function() {
   let dgeni, mockLogger;
 
   beforeEach(function() {
-    mockLogger = spy.object('log', ['error', 'warning', 'info', 'debug', 'silly']);
+    mockLogger = spy.interface('log', ['error', 'warning', 'info', 'debug', 'silly']);
     dgeni = new Dgeni();
 
     dgeni.package('mockLogger')

--- a/src/packages/trackDocLogger.spec.ts
+++ b/src/packages/trackDocLogger.spec.ts
@@ -8,7 +8,7 @@ describe('trackDocLogger', function() {
   let dgeni, mockLogger;
 
   beforeEach(function() {
-    mockLogger = spy.object('log', ['error', 'warning', 'info', 'debug', 'silly']);
+    mockLogger = spy.interface('log', ['error', 'warning', 'info', 'debug', 'silly']);
     dgeni = new Dgeni();
 
     dgeni.package('mockLogger')

--- a/src/util/getInjectables.spec.ts
+++ b/src/util/getInjectables.spec.ts
@@ -8,7 +8,7 @@ describe('getInjectables', function() {
   let getInjectables;
 
   beforeEach(function() {
-    mockInjector = spy.object({ invoke: fn => fn() });
+    mockInjector = spy.interface({ invoke: fn => fn() });
     getInjectables = getInjectablesFactory(mockInjector);
   });
 


### PR DESCRIPTION
This brings all the dependencies up to the latest version, which gets rid of the npm audit warnings about security vulnerabilities.

Fixes #155.