### PR TITLE
feat(gen-docs): Add support for TypeScript

### DIFF
--- a/src/gen-docs.ts
+++ b/src/gen-docs.ts
@@ -1,15 +1,28 @@
 #!/usr/bin/env node
 import {Dgeni} from './Dgeni';
+import {register, Options} from 'ts-node';
 
 const path = require('canonical-path');
 const myArgs = require('optimist')
-  .usage('Usage: $0 path/to/mainPackage [path/to/other/packages ...] [--log level]')
+  .usage('Usage: $0 path/to/mainPackage [path/to/other/packages ...] [--log level] [--project]')
   .demand(1)
   .argv;
 
 
 // Extract the paths to the packages from the command line arguments
-const packagePaths = myArgs._;
+const packagePaths: string[] = myArgs._;
+
+const containsTypeScript = packagePaths.some(packagePath => packagePath.endsWith('.ts'));
+// In case a package is a TypeScript file, transpile it before hand
+if ( containsTypeScript ) {
+  let typeScriptOptions: Partial<Options> = {};
+  if ( myArgs.project ) {
+    typeScriptOptions.project = myArgs.project;
+  } else {
+    typeScriptOptions.transpileOnly = true;
+  }
+  register(typeScriptOptions);
+}
 
 // Require each of these packages and then create a new dgeni using them
 const packages = packagePaths.map((packagePath) => {

--- a/src/gen-docs.ts
+++ b/src/gen-docs.ts
@@ -29,7 +29,9 @@ const packages = packagePaths.map((packagePath) => {
   if ( packagePath.indexOf('.') === 0 ) {
     packagePath = path.resolve(packagePath);
   }
-  return require(packagePath);
+
+  const pkg = require(packagePath);
+  return pkg.default || pkg;
 });
 
 const logLevel = myArgs.log || myArgs.l;


### PR DESCRIPTION
This PR adds the following features to the `dgeni`-CLI tool:

- Add support for TypeScript 8b05f8b0
- Add support for `export default` modules adec66ad

**Open points**:
- In regards to these changes, is the `typescript` package still a `devDependency`?

- Not quite sure about the `register()` option behavior. For my project, ` { project: '...' }` or `{ transpileOnly: true `} would be suifficent, but you may have a better idea?




