### PR TITLE
docs(README): fix docs on asynchronous processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,10 @@ The `$process(docs)` method can be synchronous or asynchronous:
 
 * If synchronous then it should return `undefined` or a new array of documents.
 If it returns a new array of docs then this array will replace the previous `docs` array.
-* If asynchronous then it must return a **Promise**, which should resolve to `undefined`
-or a new collection of documents. By returning a **Promise**, the processor tells Dgeni
-that it is asynchronous and Dgeni will wait for the promise to resolve before calling the
-next processor.
+* If asynchronous then it must return a **Promise**, which should resolve to an array of
+documents that will replace the previous array. By returning a **Promise**, the processor
+tells Dgeni that it is asynchronous and Dgeni will wait for the promise to resolve before
+calling the next processor.
 
 
 Here is an example of an asynchronous **Processor**
@@ -273,6 +273,7 @@ module.exports = function readFileProcessor() {
     $process(docs) {
       return qfs.readFile(this.filePath).then(function(response) {
         docs.push(response.data);
+        return docs;
       });
     }
   };


### PR DESCRIPTION
Previously, the docs on asynchronous processing mentioned that the returned promise could be resolved to `undefined`. This was inaccurate, since the promise is expected to be resolved to an array of documents.

This commit updates the docs to match the actual behavior.

[1]: https://github.com/angular/dgeni/blob/69261d6bd84074af855385d34ebd8d3a7f6f6a1e/src/Dgeni.ts#L207